### PR TITLE
Fix env var mismatch for MongoDB

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,2 @@
-MONGODB_URI=mongodb://localhost:27017/pizzatech
+MONGO_URI=mongodb://localhost:27017/pizzatech
 PORT=5000


### PR DESCRIPTION
- update backend .env.example with MONGO_URI


